### PR TITLE
VENBackspaceTextField + VENTokenField

### DIFF
--- a/VENTokenField/VENBackspaceTextField.m
+++ b/VENTokenField/VENBackspaceTextField.m
@@ -26,12 +26,14 @@
 
 - (BOOL)keyboardInputShouldDelete:(UITextField *)textField
 {
-    if (self.text.length == 0) {
+    BOOL iOS9AndBelow = [[[UIDevice currentDevice] systemVersion] floatValue] < 10.0;
+    if (iOS9AndBelow && self.text.length == 0) {
+        // In iOS10+ the textField:shouldChangeCharactersInRange:replacementString: can handle the backspace
         if ([self.backspaceDelegate respondsToSelector:@selector(textFieldDidEnterBackspace:)]) {
             [self.backspaceDelegate textFieldDidEnterBackspace:self];
         }
     }
-
+    
     return YES;
 }
 

--- a/VENTokenField/VENTokenField.m
+++ b/VENTokenField/VENTokenField.m
@@ -639,12 +639,16 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
 
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string
 {
-    if([textField isEqual:self.invisibleTextField]) {
+    NSString *newString = [textField.text stringByReplacingCharactersInRange:range withString:string];
+    BOOL iOS10OrGreater = [[[UIDevice currentDevice] systemVersion] floatValue] >= 10.0;
+    BOOL backspaceWithoutText = textField.text.length == 0 && newString.length == 0;
+    if (iOS10OrGreater && backspaceWithoutText && ([textField isEqual:self.inputTextField] || [textField isEqual:self.invisibleTextField])) {
+        // iOS 10 triggers the shouldChangeCharactersInRange: method when there is no text, previous versions of iOS do not
+        [self textFieldDidEnterBackspace:self.invisibleTextField];
         return NO;
     }
     [self unhighlightAllTokens];
     [self setCursorVisibility];
-    NSString *newString = [textField.text stringByReplacingCharactersInRange:range withString:string];
     for (NSString *delimiter in self.delimiters) {
         if (newString.length > delimiter.length &&
             [[newString substringFromIndex:newString.length - delimiter.length] isEqualToString:delimiter]) {

--- a/VENTokenField/VENTokenField.m
+++ b/VENTokenField/VENTokenField.m
@@ -664,7 +664,6 @@ static const CGFloat VENTokenFieldDefaultMaxHeight          = 150.0;
     return YES;
 }
 
-
 #pragma mark - VENBackspaceTextFieldDelegate
 
 - (void)textFieldDidEnterBackspace:(VENBackspaceTextField *)textField


### PR DESCRIPTION
- Fixed an issue where the backspace wasn't working correctly on iOS 10
